### PR TITLE
fix: update encrypt and decrypt to be PHP 7.1 + 7.2 compatible

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -86,7 +86,7 @@ class Utils {
 		$key = $this->hextobin(md5($key));
 		$initVector = pack("C*", 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
 		$openMode = openssl_encrypt($plainText, 'AES-128-CBC', $key, OPENSSL_RAW_DATA, $initVector);
-		$encryptedText = bin2hex($openMode);
+		$encryptedText = $this->hextobin($openMode);
 		return $encryptedText;
 	}
 
@@ -94,7 +94,7 @@ class Utils {
 	{
 		$key = $this->hextobin(md5($key));
 		$initVector = pack("C*", 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
-		$encryptedText = hex2bin($encryptedText);
+		$encryptedText = $this->hextobin($encryptedText);
 		$decryptedText = openssl_decrypt($encryptedText, 'AES-128-CBC', $key, OPENSSL_RAW_DATA, $initVector);
 		return $decryptedText;
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Kishanio\CCAvenue;
 
@@ -12,7 +12,7 @@ class Utils {
     {
         $this->payment = $payment;
     }
- 
+
   	public function getChecksum()
 	{
 		$str = $this->payment->getMerchantId();
@@ -60,7 +60,7 @@ class Utils {
 		for( $i = 0 ; $i < (64 - strlen($str)) ; $i++)
 			$str = "0".$str ;
 
-		for($i = 0 ; $i < $num ; $i++) 
+		for($i = 0 ; $i < $num ; $i++)
 		{
 			$str = $str."0";
 			$str = substr($str , 1 ) ;
@@ -83,69 +83,45 @@ class Utils {
 
 	public function encrypt($plainText,$key)
 	{
-		$secretKey = $this->hextobin(md5($key));
+		$key = $this->hextobin(md5($key));
 		$initVector = pack("C*", 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
-		
-	  	$openMode = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '','cbc', '');
-	  	$blockSize = mcrypt_get_block_size(MCRYPT_RIJNDAEL_128, 'cbc');
-		$plainPad = $this->pkcs5_pad($plainText, $blockSize);
-	  	
-	  	if (mcrypt_generic_init($openMode, $secretKey, $initVector) != -1) 
-		{
-		    $encryptedText = mcrypt_generic($openMode, $plainPad);
-	      	mcrypt_generic_deinit($openMode);
-		} 
-	
-		return bin2hex($encryptedText);
+		$openMode = openssl_encrypt($plainText, 'AES-128-CBC', $key, OPENSSL_RAW_DATA, $initVector);
+		$encryptedText = bin2hex($openMode);
+		return $encryptedText;
 	}
 
 	public function decrypt($encryptedText,$key)
 	{
-		$secretKey = $this->hextobin(md5($key));
+		$key = $this->hextobin(md5($key));
 		$initVector = pack("C*", 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f);
-		$encryptedText=$this->hextobin($encryptedText);
-	   	
-	  	$openMode = mcrypt_module_open(MCRYPT_RIJNDAEL_128, '','cbc', '');
-
-		mcrypt_generic_init($openMode, $secretKey, $initVector);
-		$decryptedText = mdecrypt_generic($openMode, $encryptedText);
-
-		$decryptedText = rtrim($decryptedText, "\0");
-
-	 	mcrypt_generic_deinit($openMode);
-		
+		$encryptedText = hex2bin($encryptedText);
+		$decryptedText = openssl_decrypt($encryptedText, 'AES-128-CBC', $key, OPENSSL_RAW_DATA, $initVector);
 		return $decryptedText;
-		
+
 	}
 
-	private function pkcs5_pad ($plainText, $blockSize)
-	{
-	    $pad = $blockSize - (strlen($plainText) % $blockSize);
-	    return $plainText . str_repeat(chr($pad), $pad);
-	}
-
-	private function hextobin($hexString) 
-   	{ 
-    	$length = strlen($hexString); 
-    	$binString="";   
-    	$count=0; 
-    	while($count<$length) 
-    	{       
-    	    $subString =substr($hexString,$count,2);           
-    	    $packedString = pack("H*",$subString); 
+	private function hextobin($hexString)
+   	{
+    	$length = strlen($hexString);
+    	$binString="";
+    	$count=0;
+    	while($count<$length)
+    	{
+    	    $subString =substr($hexString,$count,2);
+    	    $packedString = pack("H*",$subString);
     	    if ($count==0)
 	    {
 		$binString=$packedString;
-	    } 
-    	    
-	    else 
+	    }
+
+	    else
 	    {
 		$binString.=$packedString;
-	    } 
-    	    
-	    $count+=2; 
-    	} 
-	        return $binString; 
-    } 
- 
+	    }
+
+	    $count+=2;
+    	}
+	        return $binString;
+    }
+
 }


### PR DESCRIPTION
Added compatibility for PHP `7.1` + `7.2`

Resolves https://github.com/kishanio/CCAvenue-PHP-Library/issues/4 and https://github.com/kishanio/CCAvenue-PHP-Library/issues/3